### PR TITLE
fix: deterministic SHACL output + workerd-friendly createNamespace imports

### DIFF
--- a/scripts/extract_namespace.ts
+++ b/scripts/extract_namespace.ts
@@ -43,7 +43,7 @@ const outputFile = `${inputFile}.ts`;
 
 const outputTerms = sortedTerms.map((i) => `      "${i}",`).join("\n");
 
-const output = `import { createNamespace } from "ldkit";
+const output = `import { createNamespace } from "ldkit/namespaces";
 
 export default createNamespace(
   {

--- a/scripts/schema_to_package.ts
+++ b/scripts/schema_to_package.ts
@@ -76,7 +76,7 @@ function buildNamespacesFile(
   extras: ExtraNamespace[],
   termsByPrefix: Map<string, Set<string>>,
 ): string {
-  const lines: string[] = [`import { createNamespace } from "ldkit";`, ""];
+  const lines: string[] = [`import { createNamespace } from "ldkit/namespaces";`, ""];
   const sorted = [...extras].sort((a, b) => a.prefix.localeCompare(b.prefix));
   for (const ns of sorted) {
     const terms = [...(termsByPrefix.get(ns.prefix) ?? new Set<string>())]

--- a/scripts/schema_to_script.ts
+++ b/scripts/schema_to_script.ts
@@ -276,7 +276,7 @@ class SchemaPrinter {
     }
 
     if (declaredExtras.length > 0) {
-      lines.push(`import { createNamespace } from "ldkit";`);
+      lines.push(`import { createNamespace } from "ldkit/namespaces";`);
     }
 
     if (this.usedNamespaces.size > 0) {

--- a/scripts/shacl_to_schema.ts
+++ b/scripts/shacl_to_schema.ts
@@ -285,7 +285,11 @@ class ShaclConverter {
       }
     }
 
-    return properties;
+    // Sort by key so re-runs against the same SHACL produce diff-free output.
+    // n3 Store quad iteration order is not guaranteed stable across parses.
+    return Object.fromEntries(
+      Object.entries(properties).toSorted(([a], [b]) => a.localeCompare(b)),
+    );
   }
 
   // SHACL conjoins multiple property shapes on the same path (AND). LDkit's

--- a/tests/scripts/schema_to_script.test.ts
+++ b/tests/scripts/schema_to_script.test.ts
@@ -334,7 +334,7 @@ Deno.test("Scripts / Schema To Script / Extra namespace emits createNamespace bl
   ];
 
   const script = s`
-    import { createNamespace } from "ldkit";
+    import { createNamespace } from "ldkit/namespaces";
     import { xsd } from "ldkit/namespaces";
 
     export const ex = createNamespace(
@@ -378,7 +378,7 @@ Deno.test("Scripts / Schema To Script / Extra namespace bracket access for non-i
   ];
 
   const script = s`
-    import { createNamespace } from "ldkit";
+    import { createNamespace } from "ldkit/namespaces";
 
     export const ex = createNamespace(
       {
@@ -419,7 +419,7 @@ Deno.test("Scripts / Schema To Script / Extra namespaces sorted by IRI length de
   ];
 
   const script = s`
-    import { createNamespace } from "ldkit";
+    import { createNamespace } from "ldkit/namespaces";
 
     export const exsub = createNamespace(
       {
@@ -496,7 +496,7 @@ Deno.test("Scripts / Schema To Script / Extra namespace shadowing a built-in: bu
   ];
 
   const script = s`
-    import { createNamespace } from "ldkit";
+    import { createNamespace } from "ldkit/namespaces";
 
     export const schema = createNamespace(
       {

--- a/tests/scripts/shacl_to_schema.test.ts
+++ b/tests/scripts/shacl_to_schema.test.ts
@@ -1070,3 +1070,25 @@ ex:CustomerShape a sh:NodeShape ;
     }
   },
 );
+
+Deno.test(
+  "Scripts / SHACL to Schema / Properties emitted in deterministic (alphabetical) order regardless of source order",
+  () => {
+    // Re-running the codegen against the same SHACL input must produce zero
+    // diff. n3 Store quad iteration order is not guaranteed stable across
+    // parses, so we sort property keys before returning the schema spec.
+    const input = `${PREFIXES}
+ex:ThingShape a sh:NodeShape ;
+  sh:targetClass ex:Thing ;
+  sh:property [ sh:path ex:zeta ; sh:datatype xsd:string ] ;
+  sh:property [ sh:path ex:alpha ; sh:datatype xsd:string ] ;
+  sh:property [ sh:path ex:mu ; sh:datatype xsd:integer ] ;
+  sh:property [ sh:path ex:beta ; sh:datatype xsd:string ] .
+`;
+
+    const result = shaclToSchema(input);
+    const keys = Object.keys(result.schemas[0].properties);
+
+    assertEquals(keys, ["alpha", "beta", "mu", "zeta"]);
+  },
+);


### PR DESCRIPTION
## Summary

Two small follow-ups to #172 (SHACL → schema CLI converters):

1. **Deterministic property order.** 
 a. `n3` Store quad iteration order isn't guaranteed stable across parses, so re-running `shacl-to-schema` against the same input could produce noisy diffs in generated files.
  b. **Properties are now sorted alphabetically before emit. Adds a regression test covering this**.

2. **Workerd-friendly `createNamespace` import path.** 
a. The generated code (and a couple of internal scripts) imported `createNamespace` from the root `ldkit` entrypoint. That entrypoint transitively pulls in modules that don't load in Cloudflare Workers / workerd. 
b. Switched all 4 call sites (`scripts/extract_namespace.ts`, `scripts/schema_to_script.ts`, `scripts/schema_to_package.ts`, plus the generator) to import from `ldkit/namespaces`, which is the narrow, side-effect-free entrypoint. 
c. Tests updated to match.

Both issues were surfaced while consuming the converter in a workerd-deployed project after #172 landed.

## Test plan

- [x] `deno test tests/scripts/shacl_to_schema.test.ts tests/scripts/schema_to_script.test.ts` — 47 passed, 0 failed
- [x] New determinism test exercises the alphabetical-order invariant against intentionally out-of-order SHACL input
