### PR TITLE
fix(lens): apply search filters on @optional properties (#170)

### DIFF
--- a/library/lens/query_builder.ts
+++ b/library/lens/query_builder.ts
@@ -70,11 +70,12 @@ export class QueryBuilder {
       property: ExpandedProperty,
       varName: string,
       search?: SearchSchema,
+      optional = false,
     ) => {
       if (search === undefined) {
         return;
       }
-      const helper = new SearchHelper(property, varName, search);
+      const helper = new SearchHelper(property, varName, search, optional);
       helper.process();
       conditions.push(helper.sparqlValues);
     };
@@ -106,7 +107,8 @@ export class QueryBuilder {
         if (!includeOptional && isOptional && propertySchema === undefined) {
           return;
         }
-        if (wrapOptional && isOptional) {
+        const wrapped = wrapOptional && isOptional;
+        if (wrapped) {
           conditions.push($`\nOPTIONAL {`);
         }
         const isInverse = property["@inverse"];
@@ -118,11 +120,17 @@ export class QueryBuilder {
               this.df.variable!(`${varPrefix}_${index}`),
             ),
           );
-          populateSearchConditions(
-            property,
-            `${varPrefix}_${index}`,
-            propertySchema,
-          );
+          // A required property is filtered here, at the top level. An optional
+          // property is filtered AFTER the OPTIONAL block closes (see below) —
+          // a FILTER inside OPTIONAL only unbinds the value, it never removes
+          // the row, so the filter would be silently ignored (issue #170).
+          if (!wrapped) {
+            populateSearchConditions(
+              property,
+              `${varPrefix}_${index}`,
+              propertySchema,
+            );
+          }
         } else {
           conditions.push(
             this.df.quad(
@@ -139,8 +147,19 @@ export class QueryBuilder {
             propertySchema,
           );
         }
-        if (wrapOptional && isOptional) {
+        if (wrapped) {
           conditions.push($`\n}\n`);
+          // Emit the search FILTER for an optional property outside the
+          // OPTIONAL block so it constrains the result set. SearchHelper
+          // guards unbound values for negative operators ($not, $notIn).
+          if (ignoreInverse || !isInverse) {
+            populateSearchConditions(
+              property,
+              `${varPrefix}_${index}`,
+              propertySchema,
+              true,
+            );
+          }
         }
       });
     };

--- a/library/lens/search_helper.ts
+++ b/library/lens/search_helper.ts
@@ -9,6 +9,7 @@ export class SearchHelper {
   private readonly propertyType: string;
   private readonly varName: string;
   private readonly searchSchema: SearchSchema;
+  private readonly optional: boolean;
 
   private df: DataFactory = new DataFactory({
     blankNodePrefix: "b",
@@ -20,6 +21,7 @@ export class SearchHelper {
     property: ExpandedProperty,
     varName: string,
     searchSchema: SearchSchema,
+    optional = false,
   ) {
     this.property = property;
     this.propertyType = property["@type"] ? property["@type"] : xsd.string;
@@ -27,6 +29,9 @@ export class SearchHelper {
     this.searchSchema = this.isPlainObject(searchSchema)
       ? searchSchema
       : { $equals: searchSchema };
+    // When true, the FILTER is emitted outside an OPTIONAL block by the query
+    // builder, so negative operators must tolerate an unbound value.
+    this.optional = optional;
   }
 
   public process() {
@@ -56,6 +61,7 @@ export class SearchHelper {
 
       this.addFilter(
         $`${this.df.variable(this.varName)} ${operator} ${this.encode(value)}`,
+        key === "$not",
       );
     }
   }
@@ -118,6 +124,7 @@ export class SearchHelper {
       const values = (value as unknown[]).map((v) => $`${this.encode(v)}`);
       this.addFilter(
         $`${this.df.variable(this.varName)} ${func} (${values.join(", ")})`,
+        key === "$notIn",
       );
     }
   }
@@ -131,8 +138,17 @@ export class SearchHelper {
     this.addFilter(stringified.replace("?value", `?${this.varName}`));
   }
 
-  private addFilter(filter: SparqlValue) {
-    this.sparqlValues.push($`FILTER (${filter}) .`);
+  private addFilter(filter: SparqlValue, negatable = false) {
+    // An optional property is matched inside an OPTIONAL block, so its value
+    // may be unbound. Negative operators ($not, $notIn) must keep the rows
+    // where the property is absent — otherwise "not equal to X" would also
+    // drop resources that simply have no value. Positive operators are left
+    // bare: an unbound value makes the comparison an error, which correctly
+    // excludes the row (a resource without the value cannot match "equals X").
+    const guarded = this.optional && negatable
+      ? $`!BOUND(${this.df.variable(this.varName)}) || (${filter})`
+      : filter;
+    this.sparqlValues.push($`FILTER (${guarded}) .`);
   }
 
   private encode(value: unknown) {

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -279,3 +279,76 @@ Deno.test("E2E / Search / $id and property", async () => {
   assertEquals(results[0].movies.length, 1);
   assertEquals(results[0].movies[0], "The Shining");
 });
+
+// Regression tests for issue #170: a search filter on an @optional property
+// must actually constrain the result set. Previously the filter was emitted
+// inside the OPTIONAL block, so it was silently ignored and every resource was
+// returned. Steven Spielberg has no nickname, which exercises unbound values.
+const NicknamedDirector = {
+  name: x.name,
+  nickname: {
+    "@id": x.nickname,
+    "@optional": true,
+  },
+} as const;
+
+const nicknameStoreContent = ttl(`
+  x:QuentinTarantino x:name "Quentin Tarantino" ; x:nickname "QT" .
+  x:StanleyKubrick x:name "Stanley Kubrick" ; x:nickname "SK" .
+  x:StevenSpielberg x:name "Steven Spielberg" .
+  `);
+
+const initNickname = () => {
+  const { store, options } = initStore();
+  store.addQuads(nicknameStoreContent);
+  return { Directors: createLens(NicknamedDirector, options) };
+};
+
+Deno.test("E2E / Search / $equals on @optional property", async () => {
+  const { Directors } = initNickname();
+
+  const results = await Directors.find({
+    where: { nickname: "QT" },
+  });
+
+  // Only Quentin matches; the filter is not ignored (would be 3 with the bug).
+  assertEquals(results.length, 1);
+  assertEquals(results[0].name, "Quentin Tarantino");
+});
+
+Deno.test("E2E / Search / $equals on @optional property excludes unbound", async () => {
+  const { Directors } = initNickname();
+
+  // No resource has this nickname; Steven (no nickname) must not leak through.
+  const results = await Directors.find({
+    where: { nickname: "unknown" },
+  });
+
+  assertEquals(results.length, 0);
+});
+
+Deno.test("E2E / Search / $not on @optional property keeps unbound", async () => {
+  const { Directors } = initNickname();
+
+  const results = await Directors.find({
+    where: { nickname: { $not: "QT" } },
+  });
+
+  // Stanley (nickname "SK") and Steven (no nickname) — a negative filter keeps
+  // resources without the value. Sorted by IRI: Stanley before Steven.
+  assertEquals(results.length, 2);
+  assertEquals(results[0].name, "Stanley Kubrick");
+  assertEquals(results[1].name, "Steven Spielberg");
+});
+
+Deno.test("E2E / Search / $notIn on @optional property keeps unbound", async () => {
+  const { Directors } = initNickname();
+
+  const results = await Directors.find({
+    where: { nickname: { $notIn: ["QT", "SK"] } },
+  });
+
+  // Only Steven, whose nickname is absent, survives excluding QT and SK.
+  assertEquals(results.length, 1);
+  assertEquals(results[0].name, "Steven Spielberg");
+});


### PR DESCRIPTION
## Summary

Fixes #170.

A `find({ where })` filter on a property declared `@optional` is silently ignored. The query builder wraps the property in an `OPTIONAL` block and emits the search `FILTER` **inside** that block, where it only leaves the value unbound instead of removing the row — so every resource of the class comes back regardless of the filter.

### Root cause

In `QueryBuilder.getShape`, an `@optional` property is wrapped in `OPTIONAL { ... }` and `SearchHelper`'s `FILTER` is pushed between the opening and closing braces:

```sparql
OPTIONAL {
  ?iri <…/prop> ?iri_1 .
  FILTER (?iri_1 = "x") .   # only unbinds ?iri_1 — never removes the row
}
```

### Fix

Emit the search `FILTER` **after** the `OPTIONAL` block closes, so it constrains the result set:

```sparql
OPTIONAL { ?iri <…/prop> ?iri_1 . }
FILTER (!BOUND(?iri_1) || (?iri_1 != "x"))   # $not — keeps resources without the value
```

Operator polarity is handled explicitly:

- **Negative operators** (`$not`, `$notIn`) are guarded with `!BOUND(?v) || (...)`, so resources that *lack* the value are kept — "not equal to X" shouldn't drop resources that have no value. This matches the expected output in #170.
- **Positive operators** (`$equals`, `$gt`, `$contains`, `$in`, …) are left bare: an unbound value makes the comparison a runtime error, which SPARQL treats as `false` and correctly excludes the row (a resource without the value cannot match "equals X").

Required (non-optional) properties are unchanged — their `FILTER` still sits at the top level exactly as before, so existing behavior and tests are unaffected.

## Changes

- `library/lens/query_builder.ts` — move an optional property's search `FILTER` outside its `OPTIONAL` block; thread an `optional` flag to `SearchHelper`.
- `library/lens/search_helper.ts` — `addFilter` guards negative operators with `!BOUND(?v) || (...)` when the property is optional.
- `tests/e2e/search.test.ts` — new coverage for `$equals` / `$not` / `$notIn` on an `@optional` property, including the absent-value (unbound) cases.

## Testing

- `deno task fmt:check` — clean
- `deno task lint` — clean
- Full test suite: **288 passed, 0 failed** (4 new tests added; no existing tests changed).